### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,6 @@
 # Fantasy
+
+[![Run on Repl.it](https://repl.it/badge/github/faaabi93/fantasyfootball)](https://repl.it/github/faaabi93/fantasyfootball)
+
 blablaba
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@faaabi93/fantasyfootball).